### PR TITLE
Assessment item fixing; exercise availability premarking

### DIFF
--- a/contentpacks/__main__.py
+++ b/contentpacks/__main__.py
@@ -30,11 +30,11 @@ def make_language_pack(lang, version, sublangargs, filename, no_assessment_items
     html_exercise_path, translated_html_exercise_ids = retrieve_html_exercises(html_exercise_ids, lang)
 
     # now include only the assessment item resources that we need
-    all_assessment_data, all_assessment_files = retrieve_all_assessment_item_data()
+    all_assessment_data, all_assessment_files = retrieve_all_assessment_item_data() if not no_assessment_items else ([], set())
 
-    assessment_data = translate_assessment_item_text(all_assessment_data, content_catalog)
+    assessment_data = translate_assessment_item_text(all_assessment_data, content_catalog) if lang != "en" else all_assessment_data
 
-    node_data = remove_untranslated_exercises(node_data, translated_html_exercise_ids, assessment_data)
+    node_data = remove_untranslated_exercises(node_data, translated_html_exercise_ids, assessment_data) if lang != "en" else node_data
 
     pack_metadata = generate_kalite_language_pack_metadata(lang, version, interface_catalog, content_catalog, subtitles,
                                                            dubbed_video_count)

--- a/contentpacks/__main__.py
+++ b/contentpacks/__main__.py
@@ -78,7 +78,7 @@ def main():
 
     log_file = args["--logging"] or "debug.log"
 
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
 
     try:
         make_language_pack(lang, version, sublangs, out, no_assessment_items, no_subtitles)

--- a/contentpacks/models.py
+++ b/contentpacks/models.py
@@ -25,6 +25,9 @@ class Item(Model):
 
 
 class AssessmentItem(Model):
-    id = CharField(max_length=50, primary_key=True)
+    id = CharField(max_length=50, index=True)
+    # looks like peewee doesn't like a primary key field that's not an integer.
+    # Hence, we have a separate field for the primary key.
+    pk = PrimaryKeyField(primary_key=True)
     item_data = TextField()  # A serialized JSON blob
     author_names = CharField(max_length=200)  # A serialized JSON list

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -266,6 +266,7 @@ def bundle_language_pack(dest, nodes, frontend_catalog, backend_catalog, metadat
         db.connect()
 
         nodes = convert_dicts_to_models(nodes)
+        nodes = mark_exercises_as_available(nodes)
         nodes = list(save_models(nodes, db)) # we have to make sure to force
                                              # the evaluation of each
                                              # save_models call, in order to
@@ -325,6 +326,7 @@ def convert_dicts_to_models(nodes):
         item = Item(**node)
 
         item.__dict__.update(**node)
+
         item.available = False
 
         # make sure description is a string, not None
@@ -338,6 +340,18 @@ def convert_dicts_to_models(nodes):
         return item
 
     yield from (convert_dict_to_model(node) for node in nodes)
+
+
+def mark_exercises_as_available(nodes):
+    '''
+    Mark all exercises as available. Unavailable exercises should've been
+    removed from the topic tree by this point.
+
+    '''
+    for node in nodes:
+        if node.kind == NodeType.exercise:
+            node.available = True
+        yield node
 
 
 def convert_dicts_to_assessment_items(assessment_items):


### PR DESCRIPTION
Again, reviewing by commit is easier. Some things fixed:
- assessment items weren't getting saved into the content db, because the id was also the primary key. Now we have a separate `pk` field, and all is well now.
- Exercises are premarked as available in the `content-pack-maker` side, and now we bubble up said availability as well.
