### PR TITLE
More content pack fixes

### DIFF
--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -515,15 +515,15 @@ def recurse_availability_up_tree(nodes, db) -> [Item]:
             children_available = children.where(Item.available == True).count() > 0
             available = children_available
 
-        files_complete = children.aggregate(fn.SUM(Item.files_complete))
+        total_files = children.aggregate(fn.SUM(Item.total_files))
 
         child_remote = children.where(((Item.available == False) & (Item.kind != "Topic")) | (Item.kind == "Topic")).aggregate(fn.SUM(Item.remote_size))
         child_on_disk = children.aggregate(fn.SUM(Item.size_on_disk))
 
         if parent.available != available:
             parent.available = available
-        if parent.files_complete != files_complete:
-            parent.files_complete = files_complete
+        if parent.total_files != total_files:
+            parent.total_files = total_files
         # Ensure that the aggregate sizes are not None
         if parent.remote_size != child_remote and child_remote:
             parent.remote_size = child_remote

--- a/tests/test_contentpacks.py
+++ b/tests/test_contentpacks.py
@@ -24,7 +24,7 @@ class Test_apply_dubbed_video_map:
         output_id = "lhS-nvcK8Co"
         test_content = [{"youtube_id": input_id}]
 
-        test_dubbed = {input_id: output_id}
+        test_dubbed = {input_id: {"youtube_id": output_id, "download_size": 9001}}
         test_list, test_count = apply_dubbed_video_map(test_content, test_dubbed, [], "de")
         assert test_list
         assert isinstance(test_list, list)
@@ -197,12 +197,12 @@ class Test_retrieve_assessment_item_data:
 
     def test_image_url_converted(self):
         url_string = "A string with http://example.com/cat_pics.gif"
-        expected_string = "A string with /content/khan/cat/cat_pics.gif"
+        expected_string = "A string with /content/assessment/khan/cat/cat_pics.gif"
         assert expected_string == localize_image_urls({"item_data": url_string})["item_data"]
 
     def test_multiple_image_urls_in_one_string_converted(self):
         url_string = "A string with http://example.com/cat_pics.JPEG http://example.com/cat_pics2.gif"
-        expected_string = "A string with /content/khan/cat/cat_pics.JPEG /content/khan/cat/cat_pics2.gif"
+        expected_string = "A string with /content/assessment/khan/cat/cat_pics.JPEG /content/assessment/khan/cat/cat_pics2.gif"
         assert expected_string == localize_image_urls({"item_data": url_string})["item_data"]
 
     def test_content_link_converted(self):


### PR DESCRIPTION
WIP. Adding other fixes here.

Changes:
- Propagate `total_files` to the parent. No need to record `files_complete`.

TODO:
- investigate why videos are being duplicated.