### PR TITLE
Need to track if file is selected for download

### DIFF
--- a/contentpacks/models.py
+++ b/contentpacks/models.py
@@ -6,6 +6,7 @@ class Item(Model):
     title = CharField()
     description = TextField(default="")
     available = BooleanField()
+    schedule_download = BooleanField(default=False)
     files_complete = IntegerField(default=0)
     total_files = IntegerField(default=0)
     kind = CharField()


### PR DESCRIPTION
In order for a consistent way of downloading files, regardless of whether KA Lite is restarted, we should track user's selection of downloads. This has to be done here.