### PR TITLE
Langpack fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ contentpack: pex
 	./makecontentpacks extract_khan_assessment.py out/en.zip
 
 langpacks: pex
-	PEX_MODULE=contentpacks ./makecontentpacks ka-lite es-ES 0.15 --out=out/es-ES.zip --no-assessment-items
-	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-BR 0.15 --out=out/pt-BR.zip --no-assessment-items
-	PEX_MODULE=contentpacks ./makecontentpacks ka-lite de 0.15 --out=out/de.zip --no-assessment-items
-	PEX_MODULE=contentpacks ./makecontentpacks ka-lite fr 0.15 --out=out/fr.zip --no-assessment-items
-	PEX_MODULE=contentpacks ./makecontentpacks ka-lite zh 0.15 --out=out/zh.zip --contentlang=zh-TW --interfacelang=zh-CN --no-assessment-items
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite es-ES 0.15 --out=out/es-ES.zip --no-assessment-resources
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-BR 0.15 --out=out/pt-BR.zip --no-assessment-resources
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite de 0.15 --out=out/de.zip --no-assessment-resources
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite fr 0.15 --out=out/fr.zip --no-assessment-resources
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite zh 0.15 --out=out/zh.zip --contentlang=zh-TW --interfacelang=zh-CN --no-assessment-resources
 	unzip -p out/en.zip content.db > content.db
 	./makecontentpacks collectmetadata.py out/
 
@@ -22,6 +22,6 @@ pex: sdist
 	pex --python=python3 -r requirements.txt -o makecontentpacks --disable-cache --no-wheel dist/content-pack-maker-`python setup.py --version`.tar.gz
 
 publish:
-	scp -P 4242 out/en*.zip $(sshuser)@pantry.learningequality.org:/var/www/downloads/$(project)/$(version)/content/contentpacks/
+	scp -P 4242 out/*.zip $(sshuser)@pantry.learningequality.org:/var/www/downloads/$(project)/$(version)/content/contentpacks/
 	scp -P 4242 out/khan_assessment.zip $(sshuser)@pantry.learningequality.org:/var/www/downloads/$(project)/$(version)/content/
 	scp -P 4242 all_metadata.json $(sshuser)@pantry.learningequality.org:/var/www/downloads/$(project)/$(version)/content/contentpacks/

--- a/contentpacks/__main__.py
+++ b/contentpacks/__main__.py
@@ -2,7 +2,7 @@
 makepack
 
 Usage:
-  makecontentpacks ka-lite <lang> <version> [--subtitlelang=subtitle-lang --contentlang=content-lang --interfacelang=interface-lang --videolang=video-lang --out=outdir --logging=log_file --no-assessment-items --no-subtitles]
+  makecontentpacks ka-lite <lang> <version> [--subtitlelang=subtitle-lang --contentlang=content-lang --interfacelang=interface-lang --videolang=video-lang --out=outdir --logging=log_file --no-assessment-items --no-subtitles --no-assessment-resources]
   makecontentpacks -h | --help
   makecontentpacks --version
 
@@ -17,7 +17,7 @@ from contentpacks.utils import translate_nodes, \
 
 import logging
 
-def make_language_pack(lang, version, sublangargs, filename, no_assessment_items, no_subtitles):
+def make_language_pack(lang, version, sublangargs, filename, no_assessment_items, no_subtitles, no_assessment_resources):
     node_data, subtitle_data, interface_catalog, content_catalog, dubmap = retrieve_language_resources(version, sublangargs, no_subtitles)
 
     subtitles, subtitle_paths = subtitle_data.keys(), subtitle_data.values()
@@ -30,7 +30,10 @@ def make_language_pack(lang, version, sublangargs, filename, no_assessment_items
     html_exercise_path, translated_html_exercise_ids = retrieve_html_exercises(html_exercise_ids, lang)
 
     # now include only the assessment item resources that we need
-    all_assessment_data, all_assessment_files = retrieve_all_assessment_item_data() if not no_assessment_items else ([], set())
+    all_assessment_data, all_assessment_files = retrieve_all_assessment_item_data(
+        no_item_data=no_assessment_items,
+        no_item_resources=no_assessment_resources
+    )
 
     assessment_data = translate_assessment_item_text(all_assessment_data, content_catalog) if lang != "en" else all_assessment_data
 
@@ -74,6 +77,7 @@ def main():
     sublangs = normalize_sublang_args(args)
 
     no_assessment_items = args["--no-assessment-items"]
+    no_assessment_resources = args['--no-assessment-resources']
     no_subtitles = args['--no-subtitles']
 
     log_file = args["--logging"] or "debug.log"
@@ -81,7 +85,7 @@ def main():
     logging.basicConfig(level=logging.INFO)
 
     try:
-        make_language_pack(lang, version, sublangs, out, no_assessment_items, no_subtitles)
+        make_language_pack(lang, version, sublangs, out, no_assessment_items, no_subtitles, no_assessment_resources)
     except Exception:           # This is allowed, since we want to potentially debug all errors
         import os
         if not os.environ.get("DEBUG"):

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -58,7 +58,11 @@ def retrieve_language_resources(version: str, sublangargs: dict, no_subtitles: b
     video_ids = [node.get("id") for node in node_data if node.get("kind") == "Video"]
     subtitle_data = retrieve_subtitles(video_ids, sublangargs["video_lang"]) if not no_subtitles else {}
 
-    dubbed_video_mapping = retrieve_dubbed_video_mapping(sublangargs["video_lang"])
+    try:
+        dubbed_video_mapping = retrieve_dubbed_video_mapping(sublangargs["video_lang"])
+    except requests.exceptions.HTTPError as e:
+        logging.warning("Got an error from the KA API: {}".format(e))
+        logging.warning("I'll keep trying until they finally hand us a 200 OK.")
 
     # retrieve KA Lite po files from CrowdIn
     interface_lang = sublangargs["interface_lang"]
@@ -122,9 +126,11 @@ def retrieve_subtitles(videos: list, lang="en", force=False, threads=NUM_PROCESS
             subtitle_download_uri = "https://www.amara.org/api/videos/%s/languages/%s/subtitles/?format=vtt" % (
                 amara_id, lang)
             filename = "subtitles/{lang}/{youtube_id}.vtt".format(lang=lang, youtube_id=youtube_id)
-            subtitle_path = download_and_cache_file(subtitle_download_uri, filename=filename, ignorecache=force)
+            subtitle_path = download_and_cache_file(subtitle_download_uri, filename=filename, ignorecache=False)
+            logging.info("subtitle path: {}".format(subtitle_path))
             return youtube_id, subtitle_path
-        except (requests.HTTPError, KeyError, urllib.error.HTTPError, urllib.error.URLError):
+        except (requests.HTTPError, KeyError, urllib.error.HTTPError, urllib.error.URLError) as e:
+            logging.info("got error while downloading subtitles: {}".format(e))
             pass
 
     pools = ThreadPool(processes=threads)
@@ -145,7 +151,7 @@ def retrieve_dubbed_video_mapping(lang: str) -> dict:
 
     if lang != "en":
 
-        projection = {"videos": [OrderedDict([("youtubeId", 1), ("id", 1)])]}
+        projection = {"videos": [OrderedDict([("youtubeId", 1), ("id", 1), ("downloadSize", 1)])]}
 
         url_template = "http://www.khanacademy.org/api/v2/topics/topictree?lang={lang}&projection={projection}"
 
@@ -153,8 +159,9 @@ def retrieve_dubbed_video_mapping(lang: str) -> dict:
 
         logging.info("Retrieving Dubbed Videos for language {lang}".format(lang=lang))
 
-        dubbed_video_data = {video.get("id"): video.get("youtubeId") for video in
-                             json.loads(requests.get(url).content.decode()).get("videos", [])}
+        r = requests.get(url)
+        r.raise_for_status()
+        dubbed_video_data = r.json()
 
         logging.info("Retrieving Videos for English to map dubbed video ids")
 
@@ -165,8 +172,8 @@ def retrieve_dubbed_video_mapping(lang: str) -> dict:
         english_video_data = {video.get("id"): video.get("youtubeId") for video in
                             json.loads(requests.get(url).content.decode()).get("videos", [])}
 
-        dubbed_video_mapping = {english_video_data[id]: {"youtube_id": youtube_id, "download_size": "download_size"}
-                                for id, youtube_id in dubbed_video_data.items() if english_video_data[id] != youtube_id}
+        dubbed_video_mapping = {english_video_data[video.get("id")]: {"youtube_id": video.get("youtubeId"), "download_size": video.get("downloadSize")}
+                                for video in dubbed_video_data.get('videos', []) if english_video_data[video.get("id")] != video.get("youtubeId")}
 
     else:
         dubbed_video_mapping = {}
@@ -661,7 +668,7 @@ def _get_content_by_readable_id(readable_id):
         return CONTENT_BY_READABLE_ID.get(re.sub("\-+", "-", readable_id).lower())
 
 
-def retrieve_assessment_item_data(assessment_item, lang=None, force=False) -> (dict, [str]):
+def retrieve_assessment_item_data(assessment_item, lang=None, force=False, no_item_data=False, no_item_resources=False) -> (dict, [str]):
     """
     Retrieve assessment item data and images for a single assessment item.
     :param assessment_item: id of assessment item
@@ -669,6 +676,9 @@ def retrieve_assessment_item_data(assessment_item, lang=None, force=False) -> (d
     :param force: refetch assessment item and images even if it exists on disk
     :return: tuple of dict of assessment item data and list of paths to files
     """
+    if no_item_data:
+        return {}, []
+
     if lang:
         url = "http://www.khanacademy.org/api/v1/assessment_items/{assessment_item}?lang={lang}".format(lang=lang)
         filename = "assessment_items/{assessment_item}_{lang}.json".format(lang=lang)
@@ -688,13 +698,14 @@ def retrieve_assessment_item_data(assessment_item, lang=None, force=False) -> (d
 
     image_urls = find_all_image_urls(item_data)
     graphie_urls = find_all_graphie_urls(item_data)
+    urls = list(itertools.chain(image_urls, graphie_urls))
 
-    file_paths = []
-
-    for url in itertools.chain(image_urls, graphie_urls):
+    def _download_image_urls(url):
         filename = MANUAL_IMAGE_URL_TO_FILENAME_MAPPING.get(url, os.path.basename(url))
         filepath = _get_subpath_from_filename(filename)
-        file_paths.append(download_and_cache_file(url, filename=filepath))
+        return download_and_cache_file(url, filename=filepath)
+
+    file_paths = [] if no_item_resources else list(map(_download_image_urls, urls))
 
     item_data = localize_image_urls(item_data)
     item_data = localize_content_links(item_data)
@@ -703,7 +714,7 @@ def retrieve_assessment_item_data(assessment_item, lang=None, force=False) -> (d
     return item_data, file_paths
 
 
-def retrieve_all_assessment_item_data(lang=None, force=False, node_data=None) -> ([dict], set):
+def retrieve_all_assessment_item_data(lang=None, force=False, node_data=None, no_item_data=False, no_item_resources=False) -> ([dict], set):
     """
     Retrieve Khan Academy assessment items and associated images from KA.
     :param lang: language to retrieve data in
@@ -719,7 +730,7 @@ def retrieve_all_assessment_item_data(lang=None, force=False, node_data=None) ->
     def _download_item_data_and_files(assessment_item):
         item_id = assessment_item.get("id")
         try:
-            item_data, file_paths = retrieve_assessment_item_data(item_id, lang=lang, force=force)
+            item_data, file_paths = retrieve_assessment_item_data(item_id, lang=lang, force=force, no_item_data=no_item_data, no_item_resources=no_item_resources)
             return item_data, file_paths
         except requests.RequestException:
             return {}, []
@@ -856,7 +867,8 @@ def retrieve_html_exercises(exercises: [str], lang: str, force=False) -> (str, [
             en_file = download_and_cache_file(en_url, cachedir=EN_BUILD_DIR, ignorecache=force)
             if not filecmp.cmp(lang_file, en_file, shallow=False):
                 return exercise_id
-        except urllib.error.HTTPError:
+        except requests.exceptions.HTTPError as e:
+            logging.warning("Failed to fetch html for exercise {}, exception: {}".format(exercise_id, e))
             return None
 
     pool = ThreadPool(processes=NUM_PROCESSES)

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -3,8 +3,9 @@ import logging
 import os
 import pkgutil
 import re
+import requests
+import shutil
 import urllib.parse
-import urllib.request
 from functools import partial
 from urllib.parse import urlparse
 from contentpacks.models import Item, AssessmentItem
@@ -101,7 +102,7 @@ def cache_file(func):
 
 
 @cache_file
-def download_and_cache_file(url, path) -> str:
+def download_and_cache_file(url: str, path: str, headers: dict={}) -> str:
     """
     Download the given url if it's not saved in cachedir. Returns the
     path to the file. Always download the file if ignorecache is True.
@@ -109,7 +110,13 @@ def download_and_cache_file(url, path) -> str:
 
     logging.info("Downloading file from {url}".format(url=url))
 
-    urllib.request.urlretrieve(url, path)
+    r = requests.get(url, stream=True, headers=headers)
+    r.raise_for_status()
+
+    with open(path, "wb") as f:
+        shutil.copyfileobj(r.raw, f)
+
+    return path
 
 
 def translate_nodes(nodes: list, catalog: Catalog) -> list:


### PR DESCRIPTION
Now allows non-english content packs to be built. Fixes:

- fix the adding of `download_size` to dubbed videos.
- add the `--no-assessment-resources` flag, to make sure that the non-english content db is properly built.