### PR TITLE
Don't cache files with the same url, but different query params together.

### DIFF
--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -90,7 +90,7 @@ def cache_file(func):
                 cachedir = os.path.join(os.getcwd(), "build")
 
             if not filename:
-                filename = os.path.basename(urlparse(url).path)
+                filename = os.path.basename(urlparse(url).path) + urlparse(url).query
 
             path = os.path.join(cachedir, filename)
 


### PR DESCRIPTION
This issue https://github.com/learningequality/ka-lite/issues/5107 indicated that our assessment items for non-English languages were getting supplanted by English assessment items.

I believe this was due to the overly aggressive way that we were caching our assessment item downloads - without any disambiguation via language.

I have corrected this to add the query parameters to any cached file, to ensure that we don't cache files incorrectly.