### PR TITLE
Restore assessment item translations

### DIFF
--- a/contentpacks/__main__.py
+++ b/contentpacks/__main__.py
@@ -42,7 +42,8 @@ def make_language_pack(lang, version, sublangargs, filename, no_assessment_items
     # now include only the assessment item resources that we need
     all_assessment_data, all_assessment_files = retrieve_all_assessment_item_data(
         no_item_data=no_assessment_items,
-        no_item_resources=no_assessment_resources
+        no_item_resources=no_assessment_resources,
+        lang=lang,
     )
 
     assessment_data = list(translate_assessment_item_text(all_assessment_data, content_catalog)) if lang != "en" else all_assessment_data

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -713,8 +713,8 @@ def retrieve_assessment_item_data(assessment_item, lang=None, force=False, no_it
         return {}, []
 
     if lang:
-        url = "http://www.khanacademy.org/api/v1/assessment_items/{assessment_item}?lang={lang}".format(lang=lang)
-        filename = "assessment_items/{assessment_item}_{lang}.json".format(lang=lang)
+        url = "http://www.khanacademy.org/api/v1/assessment_items/{assessment_item}?lang={lang}".format(lang=lang, assessment_item=assessment_item)
+        filename = "assessment_items/{assessment_item}_{lang}.json".format(lang=lang, assessment_item=assessment_item)
     else:
         url = "http://www.khanacademy.org/api/v1/assessment_items/{assessment_item}"
         filename = "assessment_items/{assessment_item}.json"


### PR DESCRIPTION
Fixes https://github.com/learningequality/ka-lite/issues/5107

Strangely we don't pull in assessment items on a per-language basis, hence the bug. Now we do, plus a miscellaneous bug fix.