### PR TITLE
Force crowdin rebuilding of translations when building content packs

### DIFF
--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -142,11 +142,28 @@ def retrieve_translations(crowdin_project_name, crowdin_secret_key, lang_code="e
     request_url_template = ("https://api.crowdin.com/api/"
                             "project/{project_id}/download/"
                             "{lang_code}.zip?key={key}")
+    export_url_template = ("https://api.crowdin.com/api/"
+                            "project/{project_id}/export/"
+                            "{lang_code}.zip?key={key}")
     request_url = request_url_template.format(
         project_id=crowdin_project_name,
         lang_code=lang_code,
         key=crowdin_secret_key,
     )
+    export_url = request_url_template.format(
+        project_id=crowdin_project_name,
+        lang_code=lang_code,
+        key=crowdin_secret_key,
+    )
+
+    logging.info("requesting CrowdIn to rebuild latest translations.")
+    try:
+        requests.get(export_url)
+    except requests.exceptions.RequestException as e:
+        logging.warning(
+            "Got exception when building CrowdIn translations: {}".format(e)
+        )
+
     logging.debug("Retrieving translations from {}".format(request_url))
     zip_path = download_and_cache_file(request_url, ignorecache=force)
     zip_extraction_path = tempfile.mkdtemp()

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -125,7 +125,7 @@ def retrieve_subtitles(videos: list, lang="en", force=False, threads=NUM_PROCESS
             subtitle_path = download_and_cache_file(subtitle_download_uri, filename=filename, ignorecache=False)
             logging.info("subtitle path: {}".format(subtitle_path))
             return youtube_id, subtitle_path
-        except (requests.HTTPError, KeyError, urllib.error.HTTPError, urllib.error.URLError) as e:
+        except (requests.exceptions.RequestException, KeyError, urllib.error.HTTPError, urllib.error.URLError) as e:
             logging.info("got error while downloading subtitles: {}".format(e))
             pass
 


### PR DESCRIPTION
Fixes https://github.com/learningequality/ka-lite/issues/5114.

CrowdIn doesn't automatically allow you to download the latest translations. Instead you must ask that the translations be rebuilt or exported first before it's available. Now we ask CrowdIn to rebuild translations before downloading them.

Also, make our subtitle error handling more robust.