### PR TITLE
Eliminate widgets  permanently    

### DIFF
--- a/contentpacks/__main__.py
+++ b/contentpacks/__main__.py
@@ -24,7 +24,7 @@ from contentpacks.khanacademy import retrieve_language_resources, apply_dubbed_v
 from contentpacks.utils import translate_nodes, \
     remove_untranslated_exercises, bundle_language_pack, separate_exercise_types, \
     generate_kalite_language_pack_metadata, translate_assessment_item_text, \
-    remove_assessment_data_with_empty_widgets
+    remove_assessment_data_with_empty_widgets, remove_nonexistent_assessment_items_from_exercises
 
 import logging
 
@@ -46,7 +46,8 @@ def make_language_pack(lang, version, sublangargs, filename, no_assessment_items
         no_item_data=no_assessment_items,
         no_item_resources=no_assessment_resources
     )
-    all_assessment_data = remove_assessment_data_with_empty_widgets(all_assessment_data)
+    all_assessment_data = list(remove_assessment_data_with_empty_widgets(all_assessment_data))
+    node_data = remove_nonexistent_assessment_items_from_exercises(node_data, all_assessment_data)
 
     assessment_data = list(translate_assessment_item_text(all_assessment_data, content_catalog)) if lang != "en" else all_assessment_data
 

--- a/contentpacks/__main__.py
+++ b/contentpacks/__main__.py
@@ -23,9 +23,11 @@ from contentpacks.khanacademy import retrieve_language_resources, apply_dubbed_v
     retrieve_all_assessment_item_data
 from contentpacks.utils import translate_nodes, \
     remove_untranslated_exercises, bundle_language_pack, separate_exercise_types, \
-    generate_kalite_language_pack_metadata, translate_assessment_item_text
+    generate_kalite_language_pack_metadata, translate_assessment_item_text, \
+    remove_assessment_data_with_empty_widgets
 
 import logging
+
 
 def make_language_pack(lang, version, sublangargs, filename, no_assessment_items, no_subtitles, no_assessment_resources):
     node_data, subtitle_data, interface_catalog, content_catalog = retrieve_language_resources(version, sublangargs, no_subtitles)
@@ -44,6 +46,7 @@ def make_language_pack(lang, version, sublangargs, filename, no_assessment_items
         no_item_data=no_assessment_items,
         no_item_resources=no_assessment_resources
     )
+    all_assessment_data = remove_assessment_data_with_empty_widgets(all_assessment_data)
 
     assessment_data = list(translate_assessment_item_text(all_assessment_data, content_catalog)) if lang != "en" else all_assessment_data
 

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -619,3 +619,23 @@ def get_primary_language(lang):
         return lang.\
             split("-")\
             [0]
+
+
+def remove_assessment_data_with_empty_widgets(assessment_data):
+    outed = 0
+    for assessment in assessment_data:
+        try:
+            assessment_id = assessment.get("id")
+            item_data = ujson.loads(assessment["item_data"])
+            question_data = item_data["question"]
+
+            if question_data.get("widgets"):
+                yield assessment
+            else:
+                outed += 1
+                logging.warning("Filtering out assessment {}. Count: {}".format(assessment_id, outed))
+        except KeyError as e:
+            logging.warning("Got error when checking widgets for assessment data {id}: {e}".format(
+                id=assessment_id,
+                e=e)
+            )

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -639,3 +639,25 @@ def remove_assessment_data_with_empty_widgets(assessment_data):
                 id=assessment_id,
                 e=e)
             )
+
+
+def remove_nonexistent_assessment_items_from_exercises(node_data: list, assessment_data: iter):
+    assessment_ids = set(assessment["id"] for assessment in assessment_data)
+
+    for node in node_data:
+        if node["kind"] != NodeType.exercise:
+            yield node
+        else:
+            # import pdb; pdb.set_trace()
+            try:
+                assessment_items = node["all_assessment_items"]
+                new_assessment_items = []
+                for item in assessment_items:
+                    ass_id = item["id"]
+                    if ass_id in assessment_ids:
+                        new_assessment_items.append(item)
+                node["all_assessment_items"] = new_assessment_items
+                yield node
+            except Exception as e:
+                import pdb; pdb.set_trace()
+                print(1)


### PR DESCRIPTION
Fixes https://github.com/learningequality/ka-lite/issues/5131.

We remove the assessment items that have empty question widgets, thus eliminating questions that need the `answerArea` type of rendering.