### PR TITLE
Make version read from env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 contentpack: pex
 	mkdir -p out/
-	PEX_MODULE=contentpacks ./makecontentpacks ka-lite en 0.16 --out=out/en.zip --no-subtitles --no-assessment-resources
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite en 0.16 --out=out/en.zip --no-subtitles
 	./makecontentpacks minimize-content-pack.py out/en.zip out/en-minimal.zip
 	./makecontentpacks extract_khan_assessment.py out/en.zip
 	./makecontentpacks collectmetadata.py out/ --out=out/all_metadata.json

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -429,15 +429,22 @@ def retrieve_exercise_dict(lang=None, force=False) -> str:
 
 @cache_file
 def download_and_clean_kalite_data(url, path, lang="en") -> str:
-    data = requests.get(url)
     attempts = 1
-    while data.status_code != 200 and attempts <= 100:
-        time.sleep(30)
+    while attempts < 100:
         data = requests.get(url)
-        attempts += 1
+        try:
+            data.raise_for_status()
+            break
+        except requests.RequestException as e:
+            logging.warning("Attempt {attempt}: Got error while requesting KA data: {e!s:<80}".format(
+                attempt=attempts,
+                e=e)
+            )
+            attempts += 1
+            time.sleep(10)
+            continue
 
-    if data.status_code != 200:
-        raise requests.RequestException("Got error requesting KA data: {}".format(data.content))
+    data.raise_for_status()     # make sure that when we get here, there are no more errors from KA.
 
     node_data = ujson.loads(data.content)
 

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -503,7 +503,7 @@ def generate_kalite_language_pack_metadata(lang: str, version: str, interface_ca
     metadata = {
         "code": lang,
         'software_version': version,
-        'language_pack_version': 1,
+        'language_pack_version': int(os.environ.get("CONTENT_PACK_VERSION") or "1"),
         'percent_translated': interface_catalog.percent_translated,
         'topic_tree_translated': content_catalog.percent_translated,
         'subtitle_count': len(subtitles),


### PR DESCRIPTION
Fixes #34. We make the metadata generator read from an environment variable. If present, set the version to that (after casting to an int -- make sure it's an int!!!!)
