### PR TITLE
Used language name and native name for looking in dubbed video mappings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ es: pex
 
 
 pt-BR: pex
-	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-BR 0.16 --out=out/langpacks/pt-BR.zip --no-assessment-resources --videolang=pt
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-BR 0.16 --out=out/langpacks/pt-BR.zip --no-assessment-resources --videolang=pt-BR --contentlang=pt-BR
 
 
 sw: pex
@@ -18,7 +18,7 @@ sw: pex
 
 
 pt-PT: pex
-	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-PT 0.16 --out=out/langpacks/pt-PT.zip --no-assessment-resources --videolang=pt --contentlang=pt
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-PT 0.16 --out=out/langpacks/pt-PT.zip --no-assessment-resources --videolang=pt-PT --contentlang=pt-PT
 
 
 bn: pex

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ es: pex
 pt-BR: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-BR 0.16 --out=out/langpacks/pt-BR.zip --no-assessment-resources --videolang=pt
 
-swa: pex
-	PEX_MODULE=contentpacks ./makecontentpacks ka-lite swa 0.16 --out=out/langpacks/swa.zip --no-assessment-resources --videolang=swa --contentlang=swa
+sw: pex
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite sw 0.16 --out=out/langpacks/sw.zip --no-assessment-resources --videolang=sw --subtitlelang=sw
 
 pt-PT: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-PT 0.16 --out=out/langpacks/pt-PT.zip --no-assessment-resources --videolang=pt --contentlang=pt
@@ -61,7 +61,7 @@ ta: pex
 all: supported
 
 
-langpacks: pt-PT es pt-BR bn de fr da bg id hi xh ta ka sw
+langpacks: sw
 	unzip -p out/en.zip content.db > content.db
 	./makecontentpacks collectmetadata.py out/langpacks/ --out=out/all_metadata.json
 

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,14 @@ es: pex
 pt-BR: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-BR 0.16 --out=out/langpacks/pt-BR.zip --no-assessment-resources --videolang=pt
 
+
 sw: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite sw 0.16 --out=out/langpacks/sw.zip --no-assessment-resources --videolang=sw --subtitlelang=sw
 
+
 pt-PT: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-PT 0.16 --out=out/langpacks/pt-PT.zip --no-assessment-resources --videolang=pt --contentlang=pt
+
 
 bn: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite bn 0.16 --out=out/langpacks/bn.zip --no-assessment-resources
@@ -61,7 +64,7 @@ ta: pex
 all: supported
 
 
-langpacks: sw
+langpacks: pt-PT es pt-BR bn de fr da bg id hi xh ta ka sw
 	unzip -p out/en.zip content.db > content.db
 	./makecontentpacks collectmetadata.py out/langpacks/ --out=out/all_metadata.json
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ es: pex
 pt-BR: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-BR 0.16 --out=out/langpacks/pt-BR.zip --no-assessment-resources --videolang=pt
 
+sw: pex
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite sw 0.16 --out=out/langpacks/sw.zip --no-assessment-resources --videolang=sw
+
 pt-PT: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-PT 0.16 --out=out/langpacks/pt-PT.zip --no-assessment-resources --videolang=pt --contentlang=pt
 
@@ -58,7 +61,7 @@ ta: pex
 all: supported
 
 
-langpacks: pt-PT es pt-BR bn de fr da bg id hi xh ta ka
+langpacks: pt-PT es pt-BR bn de fr da bg id hi xh ta ka sw
 	unzip -p out/en.zip content.db > content.db
 	./makecontentpacks collectmetadata.py out/langpacks/ --out=out/all_metadata.json
 

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ es: pex
 pt-BR: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-BR 0.16 --out=out/langpacks/pt-BR.zip --no-assessment-resources --videolang=pt
 
-sw: pex
-	PEX_MODULE=contentpacks ./makecontentpacks ka-lite sw 0.16 --out=out/langpacks/sw.zip --no-assessment-resources --videolang=sw
+swa: pex
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite swa 0.16 --out=out/langpacks/swa.zip --no-assessment-resources --videolang=swa --contentlang=swa
 
 pt-PT: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pt-PT 0.16 --out=out/langpacks/pt-PT.zip --no-assessment-resources --videolang=pt --contentlang=pt

--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ Requirements:
 - Python 3.5
 
 To start development:
-------
-1. Do a `pip install -e .` inside the project's root directory.
-2. To run all tests, do a `py.test` from the project's root directory.
+-------
+
+#### Create a virtual environment “content-pack” that you will work in:
+
+- > `sudo pip install virtualenvwrapper`
+- > `mkvirtualenv content-pack`
+- > `workon content-pack`
+
+#### Install additional development tools:
+
+- > pip install -r requirements.txt
+- > pip install -r requirements_dev.txt
+
+#### To create language packs:
+
+- Run `make langpacks` from the project root directory.
+- Language packs located at `/out/langpacks/*.zip`
+
+To run all tests, do a `py.test` from the project's root directory.

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -648,7 +648,7 @@ def retrieve_kalite_data(lang=en_lang_code, force=False, ka_domain=None, no_dubb
         url = lang_url.format(projection=json.dumps(projection), lang=en_lang_code, ka_domain=ka_domain)
         download_and_clean_kalite_data(url, lang=en_lang_code, ignorecache=False, filename="en_nodes.json")
 
-        node_data = adding_dubbed_video_mappings(node_data, lang)
+        node_data = add_dubbed_video_mappings(node_data, lang)
     return node_data
 
 

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -615,8 +615,8 @@ def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no
         for node_temp in node_data_temp:
             node_kind = node_temp.get("kind")
             if (node_kind == NodeType.topic):
-                if not node_temp["title"] in topic_title_list:
-                    topic_title_list.append(node_temp["title"])
+                if not node_temp["path"] in topic_title_list:
+                    topic_title_list.append(node_temp["path"])
                     node_data.append(node_temp)
             if (node_kind == NodeType.exercise):
                 if not node_temp["id"] in exercise_ids:

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -29,6 +29,9 @@ from contentpacks.utils import NodeType, download_and_cache_file, Catalog, cache
 from contentpacks.models import AssessmentItem
 from contentpacks.generate_dubbed_video_mappings import main, DUBBED_VIDEOS_MAPPING_FILEPATH
 
+
+EN_LANG_CODE = "en"
+
 NUM_PROCESSES = 5
 
 LangpackResources = collections.namedtuple(
@@ -515,8 +518,6 @@ def download_and_clean_kalite_data(url, path, lang=EN_LANG_CODE) -> str:
     with open(path, "w") as f:
         ujson.dump(node_data, f)
 
-
-EN_LANG_CODE = "en"
 
 TOPIC_ATTRIBUTES = [
     'childData',

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -1054,17 +1054,20 @@ def retrieve_html_exercises(exercises: [str], lang: str, force=False) -> (str, [
         Download an exercise and return its exercise id *if* the
         downloaded url from the selected language is different from the english version.
         """
-        for lang in lang_codes:
-            lang_url = EXERCISE_DOWNLOAD_URL_TEMPLATE.format(id=exercise_id, lang=lang)
-            en_url = EXERCISE_DOWNLOAD_URL_TEMPLATE.format(id=exercise_id, lang=EN_LANG_CODE)
-            try:
-                lang_file = download_and_cache_file(lang_url, cachedir=BUILD_DIR, ignorecache=force)
-                en_file = download_and_cache_file(en_url, cachedir=EN_BUILD_DIR, ignorecache=force)
-                if not filecmp.cmp(lang_file, en_file, shallow=False):
-                    return exercise_id
-            except requests.exceptions.HTTPError as e:
-                logging.warning("Failed to fetch html for exercise {}, exception: {}".format(exercise_id, e))
-                return None
+        try:
+            for lang in lang_codes:
+                lang_url = EXERCISE_DOWNLOAD_URL_TEMPLATE.format(id=exercise_id, lang=lang)
+                en_url = EXERCISE_DOWNLOAD_URL_TEMPLATE.format(id=exercise_id, lang=EN_LANG_CODE)
+                try:
+                    lang_file = download_and_cache_file(lang_url, cachedir=BUILD_DIR, ignorecache=force)
+                    en_file = download_and_cache_file(en_url, cachedir=EN_BUILD_DIR, ignorecache=force)
+                    if not filecmp.cmp(lang_file, en_file, shallow=False):
+                        return exercise_id
+                except requests.exceptions.HTTPError as e:
+                    logging.warning("Failed to fetch html for lang: {}, exercise {}, exception: {}".format(lang, exercise_id, e))
+        except requests.exceptions.HTTPError as e:
+            logging.warning("Failed to fetch exercise for lang_codes: {}, exception: {}".format(lang_codes, e))
+            return None
 
     pool = ThreadPool(processes=NUM_PROCESSES)
     translated_exercises = pool.map(_download_html_exercise, exercises)

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -25,7 +25,7 @@ import sys
 from math import ceil, log, exp
 
 from contentpacks.utils import NodeType, download_and_cache_file, Catalog, cache_file,\
-    is_video_node_dubbed, get_lang_name, NodeType
+    is_video_node_dubbed, get_lang_name, NodeType, get_lang_native_name
 from contentpacks.models import AssessmentItem
 from contentpacks.generate_dubbed_video_mappings import main, DUBBED_VIDEOS_MAPPING_FILEPATH
 
@@ -619,6 +619,12 @@ def addin_dubbed_video_mappings(node_data, lang=en_lang_code):
 
     dubbed_videos_list = dubbed_videos_load.get(lang_code)
     # If dubbed_videos_list is None It means that the language code is not available in dubbed video mappings.
+
+    if not dubbed_videos_list:
+        # Look up for the native lang code name if the get_lang_name is null.
+        lang_code = get_lang_native_name(lang).lower()
+        dubbed_videos_list = dubbed_videos_load.get(lang_code)
+
     if not dubbed_videos_list:
         return node_data
 

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -652,7 +652,7 @@ def retrieve_kalite_data(lang=en_lang_code, force=False, ka_domain=None, no_dubb
     return node_data
 
 
-def adding_dubbed_video_mappings(node_data, lang=en_lang_code):
+def add_dubbed_video_mappings(node_data, lang=en_lang_code):
     # Get the dubbed videos from the spreadsheet and substitute them
     # for the video, and topic attributes of the returned data struct.
 

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -612,12 +612,6 @@ def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no
         node_data_path = download_and_clean_kalite_data(url, lang=lang_code, ignorecache=force, filename="nodes.json")
         with open(node_data_path, 'r') as f:
             node_data_temp = ujson.load(f)
-        """
-        Some translated_youtube_lang value return from KHAN API did not match
-            to the specify language code. We need to override it to use the same
-            language code.
-        Example: using pt-BR language code in the khan api will return pt translated_youtube_lang.
-        """
         for node_temp in node_data_temp:
             node_kind = node_temp.get("kind")
             if (node_kind == NodeType.topic):
@@ -635,6 +629,12 @@ def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no
                         youtube_ids.append(node_temp["youtube_id"])
                         node_data.append(node_temp)
                     elif not youtube_lang == EN_LANG_CODE:
+                        """
+                        Some translated_youtube_lang value return from KHAN API did not match
+                            to the specify language code. We need to override it to use the same
+                            language code.
+                        Example: using pt-BR language code in the khan api will return pt translated_youtube_lang.
+                        """
                         node_temp["translated_youtube_lang"] = lang
                         node_data.append(node_temp)
     if not lang == EN_LANG_CODE and not no_dubbed_videos:

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -565,7 +565,7 @@ video_attributes = [
 en_lang_code = "en"
 
 
-def retrieve_kalite_data(lang=en_lang_code, force=False, ka_domain=None, no_dubbed_videos=False, mutilple_lang_name=True) -> list:
+def retrieve_kalite_data(lang=en_lang_code, force=False, ka_domain=None, no_dubbed_videos=False) -> list:
     """
     Retrieve the KA content data direct from KA.
     Note: use the same language code in the video, topic and exercises node data to prevent issues.
@@ -603,13 +603,18 @@ def retrieve_kalite_data(lang=en_lang_code, force=False, ka_domain=None, no_dubb
             exercise_ids.append(node.get("id"))
 
     """
-    We must check if the languge code we specify has the same languge name
-        but defferent language code using get_lang_code_list function.
+    We must check if the language code we specify has the same
+        language name But different language code using get_lang_code_list function.
     """
-    lang_list = get_lang_code_list(lang)
-    if lang_list:
-        lang_node_list = []
-        for lang_code in lang_list:
+    lang_code_list = get_lang_code_list(lang)
+    if lang_code_list:
+        lang_node_list = []`
+
+        """
+        Loop the lang_code_list variable to get each language code, and used 
+            it to get another node data form khan api.
+        """
+        for lang_code in lang_code_list:
             if not lang_code == lang:
                 url = lang_url.format(projection=json.dumps(projection), lang=lang_code, ka_domain=ka_domain)
                 node_data_path = download_and_clean_kalite_data(url, lang=lang_code, ignorecache=force, filename="nodes.json")

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -72,7 +72,6 @@ VIDEO_ATTRIBUTES = [
     'kind',
     'licenseName',
     'readableId',
-    'relatedExerciseUrl',
     'relativeUrl',
     'sha',
     'slug',

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -1048,22 +1048,23 @@ def retrieve_html_exercises(exercises: [str], lang: str, force=False) -> (str, [
     EN_BUILD_DIR = os.path.join(os.getcwd(), "build", EN_LANG_CODE)
     EXERCISE_DOWNLOAD_URL_TEMPLATE = ("https://es.khanacademy.org/"
                                       "khan-exercises/exercises/{id}.html?lang={lang}")
-
+    lang_codes = get_lang_code_list(lang)
     def _download_html_exercise(exercise_id):
         """
         Download an exercise and return its exercise id *if* the
         downloaded url from the selected language is different from the english version.
         """
-        lang_url = EXERCISE_DOWNLOAD_URL_TEMPLATE.format(id=exercise_id, lang=lang)
-        en_url = EXERCISE_DOWNLOAD_URL_TEMPLATE.format(id=exercise_id, lang=EN_LANG_CODE)
-        try:
-            lang_file = download_and_cache_file(lang_url, cachedir=BUILD_DIR, ignorecache=force)
-            en_file = download_and_cache_file(en_url, cachedir=EN_BUILD_DIR, ignorecache=force)
-            if not filecmp.cmp(lang_file, en_file, shallow=False):
-                return exercise_id
-        except requests.exceptions.HTTPError as e:
-            logging.warning("Failed to fetch html for exercise {}, exception: {}".format(exercise_id, e))
-            return None
+        for lang in lang_codes:
+            lang_url = EXERCISE_DOWNLOAD_URL_TEMPLATE.format(id=exercise_id, lang=lang)
+            en_url = EXERCISE_DOWNLOAD_URL_TEMPLATE.format(id=exercise_id, lang=EN_LANG_CODE)
+            try:
+                lang_file = download_and_cache_file(lang_url, cachedir=BUILD_DIR, ignorecache=force)
+                en_file = download_and_cache_file(en_url, cachedir=EN_BUILD_DIR, ignorecache=force)
+                if not filecmp.cmp(lang_file, en_file, shallow=False):
+                    return exercise_id
+            except requests.exceptions.HTTPError as e:
+                logging.warning("Failed to fetch html for exercise {}, exception: {}".format(exercise_id, e))
+                return None
 
     pool = ThreadPool(processes=NUM_PROCESSES)
     translated_exercises = pool.map(_download_html_exercise, exercises)

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -635,6 +635,7 @@ def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no
                             language code.
                         Example: using pt-BR language code in the khan api will return pt translated_youtube_lang.
                         """
+                        youtube_ids.append(node_temp["youtube_id"])
                         node_temp["translated_youtube_lang"] = lang
                         node_data.append(node_temp)
     if not lang == EN_LANG_CODE and not no_dubbed_videos:

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -630,8 +630,8 @@ def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no
                         node_data.append(node_temp)
                     elif not youtube_lang == EN_LANG_CODE:
                         """
-                        Some translated_youtube_lang value return from KHAN API did not match
-                            to the specify language code. We need to override it to use the same
+                        Some translated_youtube_lang values return from KHAN API did not match
+                            to the specified language code. We need to override it to use the same
                             language code.
                         Example: using pt-BR language code in the khan api will return pt translated_youtube_lang.
                         """

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -603,7 +603,9 @@ def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no
     lang_codes = get_lang_code_list(lang)
 
     # Loop-thru all lang codes and populate the topic, exercise, video lists while checking for duplicates.
+    logging.info("Found %s language codes for the language %s." % (lang_codes, lang,))
     for lang_code in lang_codes:
+        logging.info("  Processing language code %s..." % lang_code)
         projection = json.dumps(PROJECTION_KEYS)
         url = API_URL.format(projection=projection, lang=lang_code, ka_domain=ka_domain)
         node_data_path = download_and_clean_kalite_data(url, lang=lang_code, ignorecache=force, filename="nodes.json")

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -680,7 +680,7 @@ def addin_dubbed_video_mappings(node_data, lang=en_lang_code):
         if node_kind == NodeType.video:
             youtube_ids.append(node.get("youtube_id"))
         if node_kind == NodeType.topic:
-            topic_title_list.append(node.get("title"))
+            topic_title_list.append(node.get("path"))
 
     en_nodes_path = os.path.join(build_path, "en_nodes.json")
     with open(en_nodes_path, 'r') as f:
@@ -693,9 +693,9 @@ def addin_dubbed_video_mappings(node_data, lang=en_lang_code):
         # Append all topics that's not in topic_title_list list.
 
         if (node_kind == NodeType.topic):
-            if not node["title"] in topic_title_list:
+            if not node["path"] in topic_title_list:
                 en_node_list.append(node)
-                topic_title_list.append(node["title"])
+                topic_title_list.append(node["path"])
 
         if (node_kind == NodeType.video):
             youtube_id = node["youtube_id"]

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -608,7 +608,7 @@ def retrieve_kalite_data(lang=en_lang_code, force=False, ka_domain=None, no_dubb
     """
     lang_code_list = get_lang_code_list(lang)
     if lang_code_list:
-        lang_node_list = []`
+        lang_node_list = []
 
         """
         Loop the lang_code_list variable to get each language code, and used 

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -34,6 +34,61 @@ EN_LANG_CODE = "en"
 
 NUM_PROCESSES = 5
 
+TOPIC_ATTRIBUTES = [
+    'childData',
+    'deleted',
+    'description',
+    'doNotPublish',
+    'hide',
+    'id',
+    'kind',
+    'slug',
+    'title'
+]
+
+EXERCISE_ATTRIBUTES = [
+    'allAssessmentItems',
+    'curatedRelatedVideos',
+    'description',
+    'displayName',
+    'fileName',
+    'id',
+    'kind',
+    'name',
+    'prerequisites',
+    'slug',
+    'title',
+    'usesAssessmentItems'
+]
+
+VIDEO_ATTRIBUTES = [
+    'description',
+    'downloadSize',
+    'duration',
+    'id',
+    'imageUrl',
+    'keywords',
+    'kind',
+    'licenseName',
+    'readableId',
+    'relatedExerciseUrl',
+    'relativeUrl',
+    'sha',
+    'slug',
+    'title',
+    'translatedYoutubeLang',
+    'youtubeId'
+]
+
+PROJECTION_KEYS = OrderedDict([
+    ("topics", [OrderedDict((key, 1) for key in TOPIC_ATTRIBUTES)]),
+    ("exercises", [OrderedDict((key, 1) for key in EXERCISE_ATTRIBUTES)]),
+    ("videos", [OrderedDict((key, 1) for key in VIDEO_ATTRIBUTES)])
+])
+
+API_URL = "http://{ka_domain}/api/v2/topics/topictree?lang={lang}&projection={projection}"
+KA_DOMAIN = "www.khanacademy.org"
+
 LangpackResources = collections.namedtuple(
     "LangpackResources",
     ["node_data",
@@ -519,62 +574,6 @@ def download_and_clean_kalite_data(url, path, lang=EN_LANG_CODE) -> str:
         ujson.dump(node_data, f)
 
 
-TOPIC_ATTRIBUTES = [
-    'childData',
-    'deleted',
-    'description',
-    'doNotPublish',
-    'hide',
-    'id',
-    'kind',
-    'slug',
-    'title'
-]
-
-EXERCISE_ATTRIBUTES = [
-    'allAssessmentItems',
-    'curatedRelatedVideos',
-    'description',
-    'displayName',
-    'fileName',
-    'id',
-    'kind',
-    'name',
-    'prerequisites',
-    'slug',
-    'title',
-    'usesAssessmentItems'
-]
-
-VIDEO_ATTRIBUTES = [
-    'description',
-    'downloadSize',
-    'duration',
-    'id',
-    'imageUrl',
-    'keywords',
-    'kind',
-    'licenseName',
-    'readableId',
-    'relatedExerciseUrl',
-    'relativeUrl',
-    'sha',
-    'slug',
-    'title',
-    'translatedYoutubeLang',
-    'youtubeId'
-]
-
-PROJECTION_KEYS = OrderedDict([
-    ("topics", [OrderedDict((key, 1) for key in TOPIC_ATTRIBUTES)]),
-    ("exercises", [OrderedDict((key, 1) for key in EXERCISE_ATTRIBUTES)]),
-    ("videos", [OrderedDict((key, 1) for key in VIDEO_ATTRIBUTES)])
-])
-
-API_URL = "http://{ka_domain}/api/v2/topics/topictree?lang={lang}&projection={PROJECTION_KEYS}"
-KA_DOMAIN = "www.khanacademy.org"
-
-
 def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no_dubbed_videos=False) -> list:
     """
     Retrieve the KA content data direct from KA.
@@ -605,7 +604,8 @@ def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no
 
     # Loop-thru all lang codes and populate the topic, exercise, video lists while checking for duplicates.
     for lang_code in lang_codes:
-        url = API_URL.format(projection=json.dumps(PROJECTION_KEYS), lang=lang_code, ka_domain=ka_domain)
+        projection = json.dumps(PROJECTION_KEYS)
+        url = API_URL.format(projection=projection, lang=lang_code, ka_domain=ka_domain)
         node_data_path = download_and_clean_kalite_data(url, lang=lang_code, ignorecache=force, filename="nodes.json")
         with open(node_data_path, 'r') as f:
             node_data_temp = ujson.load(f)

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -634,8 +634,8 @@ def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no
                     if youtube_lang == lang:
                         youtube_ids.append(node_temp["youtube_id"])
                         node_data.append(node_temp)
-                    elif not youtube_lang != EN_LANG_CODE:
-                        node_temp["translated_youtube_lang"] == lang
+                    elif not youtube_lang == EN_LANG_CODE:
+                        node_temp["translated_youtube_lang"] = lang
                         node_data.append(node_temp)
     if not lang == EN_LANG_CODE and not no_dubbed_videos:
         node_data = add_dubbed_video_mappings(node_data, lang)

--- a/contentpacks/resources/languagelookup.json
+++ b/contentpacks/resources/languagelookup.json
@@ -771,9 +771,13 @@
     "name":"Swedish",
     "native_name":"Svenska"
   },
-  "ur-PK":{
+  "sv-FI":{
     "name":"Swedish",
     "native_name":"Svenska"
+  },
+  "ur-PK":{
+    "name":"Urdu",
+    "native_name":"Urdu"
   },
   "zh-CN":{
     "name":"Chinese, Simplified",

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -517,32 +517,29 @@ def generate_kalite_language_pack_metadata(lang: str, version: str, interface_ca
 
 
 def get_lang_name(lang):
-    langlookup = ujson.loads(LANGUAGELOOKUP_DATA)
-
     try:
+        langlookup = ujson.loads(LANGUAGELOOKUP_DATA)
         return langlookup[lang]["name"]
     except KeyError:
         logging.warning("No name found for {}. Defaulting to DEBUG.".format(lang))
-        return "DEBUG"
+        return ""
 
 
 def get_lang_native_name(lang):
-    langlookup = ujson.loads(LANGUAGELOOKUP_DATA)
-
-    try:
-        return langlookup[lang]["native_name"]
-    except KeyError:
-        logging.warning("No native name found for {}. Defaulting to DEBUG.".format(lang))
-        return "DEBUG"
-
-
-def get_lang_ka_name(lang):
     try:
         langlookup = ujson.loads(LANGUAGELOOKUP_DATA)
         return langlookup[lang]["native_name"]
     except KeyError:
+        logging.warning("No native name found for {}. Defaulting to DEBUG.".format(lang))
+        return ""
+
+def get_lang_ka_name(lang):
+    try:
+        langlookup = ujson.loads(LANGUAGELOOKUP_DATA)
+        return langlookup[lang]["ka_name"]
+    except KeyError:
         logging.warning("No ka name found for {}. Defaulting to DEBUG.".format(lang))
-        return "DEBUG"
+        return ""
 
 
 def get_lang_code_list(lang):

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -537,10 +537,30 @@ def get_lang_native_name(lang):
 
 
 def get_lang_code_list(lang):
-    langlookup = ujson.loads(LANGUAGELOOKUP_DATA)
-    lang_name = langlookup[lang]["name"]
+    """
+    Returns a list of language codes that has a similar language name to the specified language code.
 
+    Example 1: Swahili language has { 
+                "sw":{ "name":"Swahili", "native_name":"Kiswahili" },
+                "swa":{ "name":"Swahili", "native_name":"Kiswahili" },
+            }
+            Function call is `get_lang_code_list("sw")`.
+            Return is `["sw", "swa"]`.
+
+    Example 2: Somali language has {
+                "som":{ "name":"Somali", "native_name":"Soomaaliga" },
+                "so":{ "name":"Somali", "native_name":"Soomaaliga, af Soomaali" },
+            }
+            Function call is `get_lang_code_list("so")`.
+            Return is `["so", "som"]`.
+    """
     try:
+        langlookup = ujson.loads(LANGUAGELOOKUP_DATA)
+        lang_name = langlookup[lang]["name"]
+
+        # TODO: Replace with list comprehension?
+        # lang_code_list = [obj[0] for obj in langlookup.items() if obj[1]["name"] == lang_name]
+
         lang_code_list = []
         for obj in langlookup.items():
             name = obj[1]["name"]
@@ -548,8 +568,8 @@ def get_lang_code_list(lang):
                 lang_code_list.append(obj[0])
         return lang_code_list
     except KeyError:
-        logging.warning("No language code found for {}. Defaulting to DEBUG.".format(lang_name))
-        return "DEBUG"
+        logging.warning("No language code found for {}. Defaulting to an empty list.".format(lang_name))
+        return []
 
 
 def save_metadata(zf, metadata):

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -536,6 +536,22 @@ def get_lang_native_name(lang):
         return "DEBUG"
 
 
+def get_lang_code_list(lang):
+    langlookup = ujson.loads(LANGUAGELOOKUP_DATA)
+    lang_name = langlookup[lang]["name"]
+
+    try:
+        lang_code_list = []
+        for obj in langlookup.items():
+            name = obj[1]["name"]
+            if name == lang_name:
+                lang_code_list.append(obj[0])
+        return lang_code_list
+    except KeyError:
+        logging.warning("No languge code found for {}. Defaulting to DEBUG.".format(lang_name))
+        return "DEBUG"
+
+
 def save_metadata(zf, metadata):
     dump = ujson.dumps(metadata)
     metadata_name = "metadata.json"

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -536,6 +536,15 @@ def get_lang_native_name(lang):
         return "DEBUG"
 
 
+def get_lang_ka_name(lang):
+    try:
+        langlookup = ujson.loads(LANGUAGELOOKUP_DATA)
+        return langlookup[lang]["native_name"]
+    except KeyError:
+        logging.warning("No ka name found for {}. Defaulting to DEBUG.".format(lang))
+        return "DEBUG"
+
+
 def get_lang_code_list(lang):
     """
     Returns a list of language codes that has a similar language name to the specified language code.

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -548,7 +548,7 @@ def get_lang_code_list(lang):
                 lang_code_list.append(obj[0])
         return lang_code_list
     except KeyError:
-        logging.warning("No languge code found for {}. Defaulting to DEBUG.".format(lang_name))
+        logging.warning("No language code found for {}. Defaulting to DEBUG.".format(lang_name))
         return "DEBUG"
 
 


### PR DESCRIPTION
This fixes #38 & [#5294](https://github.com/learningequality/ka-lite/issues/5294)

Used language name and native name as reference when looking in [dubbed video mappings](https://docs.google.com/spreadsheets/d/1k5xh2UXV3EchRHnYzeP6-YGKrmba22vsltGSuU9bL88/edit#gid=0).

It may also solve other languages that use the native name in [dubbed video mappings](https://docs.google.com/spreadsheets/d/1k5xh2UXV3EchRHnYzeP6-YGKrmba22vsltGSuU9bL88/edit#gid=0).

I uploaded a sample screenshot of `Swahili` when downloading videos.
![screen shot 2016-09-28 at 9 07 44 am](https://cloud.githubusercontent.com/assets/8663934/18898304/562ead5c-8563-11e6-9739-90868cbd4d2f.png)

I also uploaded the `Swahili` language pack for testing.
[sw.zip](https://github.com/fle-internal/content-pack-maker/files/496997/sw.zip)

/cc @aronasorman @jamalex @mrpau-eduard @benjaoming 
