### PR TITLE
Include exercises data for multi lang code support.

### DIFF
--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -478,12 +478,13 @@ def download_exercise_data(url, path) -> str:
 
 
 def retrieve_exercise_dict(lang=None, force=False) -> str:
-    url = "https://www.khanacademy.org/api/internal/exercises" + ("?lang={lang}".format(lang=lang) if lang else "")
-
-    exercise_data_path = download_exercise_data(url, ignorecache=force, filename="exercises.json")
-
-    with open(exercise_data_path, 'r') as f:
-        exercise_data = ujson.load(f)
+    lang_codes = get_lang_code_list(lang)
+    exercise_data = []
+    for lang in lang_codes:
+        url = "https://www.khanacademy.org/api/internal/exercises" + ("?lang={lang}".format(lang=lang) if lang else "")
+        exercise_data_path = download_exercise_data(url, ignorecache=force, filename="exercises.json")
+        with open(exercise_data_path, 'r') as f:
+            exercise_data = ujson.load(f)
 
     return {ex.get("id"): ex for ex in exercise_data}
 

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -574,7 +574,7 @@ def get_lang_code_list(lang):
                 lang_code_list.append(obj[0])
         return lang_code_list
     except KeyError:
-        logging.warning("No language code found for {}. Defaulting to an empty list.".format(lang_name))
+        logging.warning("No language code found for {}. Defaulting to an empty list.".format(lang))
         return []
 
 


### PR DESCRIPTION
## Summary

Hi @cpauya .
This fixes the exercise content data is not found for Swahili language packs.
## Screenshots (if appropriate)

![screen shot 2016-10-28 at 9 06 38 pm](https://cloud.githubusercontent.com/assets/20859877/19807392/77c6cae2-9d52-11e6-9aa5-3e0ffcd303f6.png)
