### PR TITLE
Use the crowdin api status to calculate the translation percentage.

### DIFF
--- a/contentpacks/__main__.py
+++ b/contentpacks/__main__.py
@@ -58,7 +58,7 @@ def make_language_pack(lang, version, sublangargs, filename, ka_domain, no_asses
 
     node_data = remove_untranslated_exercises(node_data, translated_html_exercise_ids, assessment_data) if lang != "en" else node_data
 
-    pack_metadata = generate_kalite_language_pack_metadata(lang, version, interface_catalog, content_catalog, subtitles,
+    pack_metadata = generate_kalite_language_pack_metadata(lang, version, sublangargs, interface_catalog, content_catalog, subtitles,
                                                            dubbed_video_count)
 
     bundle_language_pack(str(filename), node_data, interface_catalog, interface_catalog,

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -1,19 +1,21 @@
 import copy
 import logging
 import os
+import pathlib
+import polib
 import pkgutil
 import re
 import requests
+import urllib.request
+import ujson
+import tempfile
+import zipfile
+
+from decimal import Decimal
 from functools import partial
 from urllib.parse import urlparse
 from contentpacks.models import Item, AssessmentItem
 from peewee import Using, SqliteDatabase, fn
-import polib
-import ujson
-import zipfile
-import tempfile
-import urllib.request
-import pathlib
 
 
 class UnexpectedKindError(Exception):
@@ -81,33 +83,36 @@ class Catalog(dict):
 
         return (trans_count / all_strings_count) * 100
 
-    def get_interface_percent_translated(self, lang=None, version=None):
+    def compute_interface_translated_percentage(self, lang, version):
         """
-        Get the ka-lite crowdin api status and return the translated percentage.
+        Fetch the translated status from crowdin api then calculate the percentage of the translated words from
+        the {version}-djangojs.po and {version}-django.po.
+        Returns the calculated percentage.
         """
         crowdin_url = CROWDIN_API.format(crowdin_project=KALITE_PROJECT, crowdin_secret_key=KALITE_SECRET_KEY,
                                          lang=lang)
+        logging.info("Fetch crowdin status from (%s)" % crowdin_url)
         crowdin_data = urllib.request.urlopen(crowdin_url)
         data = ujson.loads(crowdin_data.read())
         version_files = data["files"][0]
-        total_translated_data = 0
-        pofile_data = 0
-        for key, val in enumerate(version_files["files"]):
-            djangojs_po = "%s-djangojs.po" % version
-            django_po = "%s-django.po" % version
-            if djangojs_po == val.get("name"):
-                for node_key, node_val in val.items():
-                    if node_key == "words_approved":
-                        total_translated_data += int(node_val)
-                    if node_key == "words":
-                        pofile_data += int(node_val)
-            if django_po == val.get("name"):
-                for node_key, node_val in val.items():
-                    if node_key == "words_approved":
-                        total_translated_data += int(node_val)
-                    if node_key == "words":
-                        pofile_data += int(node_val)
-        percent_translated = (total_translated_data / pofile_data) * 100
+        total_words_approved = 0
+        total_words = 0
+        djangojs_po = "%s-djangojs.po" % version
+        django_po = "%s-django.po" % version
+        # Loop on the `files` dict to get the translated status.
+        for filenames in version_files.get("files"):
+            # Get only the {version}-djangojs.po and {version}-django.po data.
+            if djangojs_po == filenames.get("name"):
+                total_words_approved += Decimal(filenames.get("words_approved"))
+                total_words += Decimal(filenames.get("words"))
+            if django_po == filenames.get("name"):
+                total_words_approved += Decimal(filenames.get("words_approved"))
+                total_words += Decimal(filenames.get("words"))
+        if total_words == 0:
+            logging.info("Check the api status for lang:(%s) and version:(%s).The total_words returns 0 value." %
+                         (lang, version))
+            raise ZeroDivisionError
+        percent_translated = (total_words_approved / total_words) * 100
         return percent_translated
 
 
@@ -536,7 +541,7 @@ def generate_kalite_language_pack_metadata(lang: str, version: str, interface_ca
         "code": lang,
         'software_version': version,
         'language_pack_version': int(os.environ.get("CONTENT_PACK_VERSION") or "1"),
-        'percent_translated': interface_catalog.get_interface_percent_translated(lang=lang, version=version),
+        'percent_translated': interface_catalog.compute_interface_translated_percentage(lang=lang, version=version),
         'topic_tree_translated': content_catalog.percent_translated,
         'subtitle_count': len(subtitles),
         "name": get_lang_name(lang),

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -85,7 +85,7 @@ class Catalog(dict):
 
     def compute_interface_translated_percentage(self, lang, version):
         """
-        Fetch the translated status from crowdin api then calculate the percentage of the translated words from
+        Fetch the translated status from CrowdIn API then calculate the percentage of the translated words from
         the {version}-djangojs.po and {version}-django.po.
         Returns the calculated percentage.
         """

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -100,19 +100,21 @@ class Catalog(dict):
         djangojs_po = "%s-djangojs.po" % version
         django_po = "%s-django.po" % version
         # Loop on the `files` dict to get the translated status.
-        for filenames in version_files.get("files"):
+        for filename in version_files.get("files"):
             # Get only the {version}-djangojs.po and {version}-django.po data.
-            if djangojs_po == filenames.get("name"):
-                total_words_approved += Decimal(filenames.get("words_approved"))
-                total_words += Decimal(filenames.get("words"))
-            if django_po == filenames.get("name"):
-                total_words_approved += Decimal(filenames.get("words_approved"))
-                total_words += Decimal(filenames.get("words"))
+            if djangojs_po == filename.get("name"):
+                total_words_approved += Decimal(filename.get("words_approved"))
+                total_words += Decimal(filename.get("words"))
+            if django_po == filename.get("name"):
+                total_words_approved += Decimal(filename.get("words_approved"))
+                total_words += Decimal(filename.get("words"))
         if total_words == 0:
             logging.info("Check the api status for lang:(%s) and version:(%s).The total_words returns 0 value." %
                          (lang, version))
-            raise ZeroDivisionError
-        percent_translated = (total_words_approved / total_words) * 100
+            # Since the `total_words` is 0. The `percent_translated` will default to 0 to avoid Division by zero error.
+            percent_translated = total_words
+        else:
+            percent_translated = (total_words_approved / total_words) * 100
         return percent_translated
 
 

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -528,7 +528,7 @@ def separate_exercise_types(node_data):
            node_data
 
 
-def generate_kalite_language_pack_metadata(lang: str, version: str, interface_catalog: Catalog,
+def generate_kalite_language_pack_metadata(lang: str, version: str, sublangargs: dict, interface_catalog: Catalog,
                                            content_catalog: Catalog, subtitles: list, dubbed_video_count: int):
     """
     Create the language pack metadata based on the files passed in.
@@ -536,12 +536,14 @@ def generate_kalite_language_pack_metadata(lang: str, version: str, interface_ca
 
     # language packs are automatically beta if they have no dubbed videos and subtitles
     is_beta = dubbed_video_count == 0 and len(subtitles) == 0
+    interface_lang = sublangargs["interface_lang"]
 
     metadata = {
         "code": lang,
         'software_version': version,
         'language_pack_version': int(os.environ.get("CONTENT_PACK_VERSION") or "1"),
-        'percent_translated': interface_catalog.compute_interface_translated_percentage(lang=lang, version=version),
+        'percent_translated': interface_catalog.compute_interface_translated_percentage(lang=interface_lang or lang,
+                                                                                        version=version),
         'topic_tree_translated': content_catalog.percent_translated,
         'subtitle_count': len(subtitles),
         "name": get_lang_name(lang),


### PR DESCRIPTION
## Summary
Hi @benjaoming this fixes the issue of language packs that giving the wrong translated percentage in the language packs `metadata.json`. 
There are discrepancy on [all_metadata.json](http://pantry.learningequality.org/downloads/ka-lite/0.17/content/contentpacks/all_metadata.json) from the pantry and the newly build contentpack with this fix.
pantry: `sw`: 84.729981378 and `pt-PT`: 87.895716946 
build by this fix: `sw`: 94.0412664532 and `pt-PT`: 100.0

Use of the [CrowdIn API](https://support.crowdin.com/api/status/) as per suggested by @benjaoming and peer reviewed by @cpauya .
## Issues addressed
#61 
## Sample output 
```
{
  "beta": false,
  "code": "sw",
  "language_pack_version": 1,
  "name": "Swahili",
  "native_name": "Kiswahili",
  "percent_translated": 94.0412664532,
  "software_version": "0.17",
  "subtitle_count": 0,
  "topic_tree_translated": 7.7005868209,
  "video_count": 697
},
{
  "beta": false,
  "code": "pt-PT",
  "language_pack_version": 1,
  "name": "Portuguese, Portugal",
  "native_name": "Português",
  "percent_translated": 100.0,
  "software_version": "0.17",
  "subtitle_count": 5,
  "topic_tree_translated": 24.5642315162,
  "video_count": 1584
}
```