### PR TITLE
Translations fixes

### DIFF
--- a/contentpacks/__main__.py
+++ b/contentpacks/__main__.py
@@ -49,6 +49,7 @@ def make_language_pack(lang, version, sublangargs, filename, ka_domain, no_asses
         no_item_resources=no_assessment_resources,
         node_data=node_data,
         lang=lang,
+        content_catalog=content_catalog,
     )
     all_assessment_data = list(remove_assessment_data_with_empty_widgets(all_assessment_data))
     node_data = remove_nonexistent_assessment_items_from_exercises(node_data, all_assessment_data)

--- a/contentpacks/__main__.py
+++ b/contentpacks/__main__.py
@@ -54,7 +54,7 @@ def make_language_pack(lang, version, sublangargs, filename, ka_domain, no_asses
     node_data = remove_nonexistent_assessment_items_from_exercises(node_data, all_assessment_data)
 
     node_data = clean_node_data_items(node_data)
-    assessment_data = list(translate_assessment_item_text(all_assessment_data, content_catalog)) if lang != "en" else all_assessment_data
+    assessment_data = list(all_assessment_data)
 
     node_data = remove_untranslated_exercises(node_data, translated_html_exercise_ids, assessment_data) if lang != "en" else node_data
 

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -78,7 +78,8 @@ VIDEO_ATTRIBUTES = [
     'slug',
     'title',
     'translatedYoutubeLang',
-    'youtubeId'
+    'youtubeId',
+    'descriptionHtml'
 ]
 
 PROJECTION_KEYS = OrderedDict([

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -895,6 +895,14 @@ def retrieve_assessment_item_data(assessment_item, lang=None, force=False, no_it
     with open(path, "r") as f:
         item_data = json.load(f)
 
+    # TEMP HACK: translate the item text here before URLs are localized, because otherwise, later, Crowdin strings no longer match
+    if lang != "en" and content_catalog is not None:
+        item_data = list(translate_assessment_item_text([item_data], content_catalog))
+        if item_data:
+            item_data = item_data[0]
+        else:  # if no translation, return empty assessment_item
+            return {}, []
+
     image_urls = find_all_image_urls(item_data)
     graphie_urls = find_all_graphie_urls(item_data)
     urls = list(itertools.chain(image_urls, graphie_urls))

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -27,7 +27,7 @@ from math import ceil, log, exp
 
 from contentpacks.utils import NodeType, download_and_cache_file, Catalog, cache_file,\
     is_video_node_dubbed, get_lang_name, NodeType, get_lang_native_name,\
-    get_lang_ka_name, get_lang_code_list
+    get_lang_ka_name, get_lang_code_list, translate_assessment_item_text
 from contentpacks.models import AssessmentItem
 from contentpacks.generate_dubbed_video_mappings import main, DUBBED_VIDEOS_MAPPING_FILEPATH
 
@@ -867,7 +867,7 @@ def _get_content_by_readable_id(readable_id):
         return CONTENT_BY_READABLE_ID.get(re.sub("\-+", "-", readable_id).lower())
 
 
-def retrieve_assessment_item_data(assessment_item, lang=None, force=False, no_item_data=False, no_item_resources=False) -> (dict, [str]):
+def retrieve_assessment_item_data(assessment_item, lang=None, force=False, no_item_data=False, no_item_resources=False, content_catalog=None) -> (dict, [str]):
     """
     Retrieve assessment item data and images for a single assessment item.
     :param assessment_item: id of assessment item
@@ -928,7 +928,7 @@ def retrieve_assessment_item_data(assessment_item, lang=None, force=False, no_it
     return item_data, file_paths
 
 
-def retrieve_all_assessment_item_data(lang=None, force=False, node_data=None, no_item_data=False, no_item_resources=False) -> ([dict], set):
+def retrieve_all_assessment_item_data(lang=None, force=False, node_data=None, no_item_data=False, no_item_resources=False, content_catalog=None) -> ([dict], set):
     """
     Retrieve Khan Academy assessment items and associated images from KA.
     :param lang: language to retrieve data in
@@ -944,7 +944,7 @@ def retrieve_all_assessment_item_data(lang=None, force=False, node_data=None, no
     def _download_item_data_and_files(assessment_item):
         item_id = assessment_item.get("id")
         try:
-            item_data, file_paths = retrieve_assessment_item_data(item_id, lang=lang, force=force, no_item_data=no_item_data, no_item_resources=no_item_resources)
+            item_data, file_paths = retrieve_assessment_item_data(item_id, lang=lang, force=force, no_item_data=no_item_data, no_item_resources=no_item_resources, content_catalog=content_catalog)
             return item_data, file_paths
         except requests.RequestException as e:
             logging.warning("got requests exception: {}".format(e))

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -7,6 +7,7 @@ import pkgutil
 import re
 import requests
 import urllib.request
+import json
 import ujson
 import tempfile
 import zipfile
@@ -208,13 +209,13 @@ def translate_assessment_item_text(items: list, catalog: Catalog):
     for item in items:
         item = copy.copy(item)
 
-        item_data = ujson.loads(item["item_data"])
+        item_data = json.loads(item["item_data"])
         try:
             translated_item_data = smart_translate_item_data(item_data, gettext)
         except NotTranslatable:
             continue
         else:
-            item["item_data"] = ujson.dumps(translated_item_data, gettext)
+            item["item_data"] = json.dumps(translated_item_data, gettext)
             yield item
 
 

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -208,8 +208,6 @@ def translate_assessment_item_text(items: list, catalog: Catalog):
         Convenience function for translating text through the given catalog.
         """
         trans = catalog.get(s) or s
-        if trans is '' or trans is None:
-            raise NotTranslatable
 
         return trans
 
@@ -261,19 +259,16 @@ def remove_untranslated_exercises(nodes, html_ids, translated_assessment_data):
     def is_translated_exercise(ex):
 
         ex_id = ex["id"]
-        num_correct_in_a_row = ex.get('suggested_completion_criteria')
-        present_items = 0
         if ex_id in html_ids:  # translated html exercise
             return True
         elif ex["uses_assessment_items"]:
-            # we remove the exercise if the number of available translated items is less then the mastery model
             for item_data in ex["all_assessment_items"]:
                 assessment_id = item_data["id"]
                 if assessment_id in item_data_ids:
-                    present_items = present_items + 1
-            if present_items < num_correct_in_a_row:
-                return False
-        return True
+                    continue
+                else:
+                    return False
+            return True
 
     for node in nodes:
         if node["kind"] != NodeType.exercise:

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -14,6 +14,7 @@ import zipfile
 
 from decimal import Decimal
 from functools import partial
+from html2text import html2text
 from urllib.parse import urlparse
 from contentpacks.models import Item, AssessmentItem
 from peewee import Using, SqliteDatabase, fn
@@ -37,6 +38,7 @@ NODE_FIELDS_TO_TRANSLATE = [
     "title",
     "description",
     "display_name",
+    "descriptionHtml"
 ]
 
 
@@ -180,6 +182,9 @@ def translate_nodes(nodes: list, catalog: Catalog) -> list:
             if msgid:
                 try:
                     node[field] = catalog[msgid]
+                    # use descriptionHtml field because some untranslated strings for videos have html in them
+                    if field == "descriptionHtml":
+                        node["description"] = html2text(node[field])
                 except KeyError:
                     logging.debug("could not translate {field} for {title}".format(field=field, title=node["title"]))
 

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -230,12 +230,7 @@ def smart_translate_item_data(item_data: dict, gettext):
     """
     translate_item_fn = partial(smart_translate_item_data, gettext=gettext)
 
-    # TODO (aronasorman): implement tests
-    # just translate strings immediately
-    if isinstance(item_data, str):
-        return gettext(item_data)
-
-    elif isinstance(item_data, list):
+    if isinstance(item_data, list):
         return list(map(translate_item_fn, item_data))
 
     elif isinstance(item_data, dict):
@@ -248,7 +243,7 @@ def smart_translate_item_data(item_data: dict, gettext):
             elif isinstance(field_data, list):
                 item_data[field] = list(map(translate_item_fn, field_data))
 
-        return item_data
+    return item_data
 
 
 def remove_untranslated_exercises(nodes, html_ids, translated_assessment_data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ decorator==4.0.10
 httplib2==0.9.2
 gspread==0.4.1
 oauth2client==4.0.0
+html2text


### PR DESCRIPTION
- We don't need to translate strings directly, except when they have the `content` key. Also we should return untranslated items such as numbers in a list.
- When doing `ujson.dumps()`, it adds extra slashes to the string. This throws off regexes parsing those strings.
- We need to translate descriptions for videos using `htmlDescription` because some of these strings have html in them. 
- We need to translate assessment items before localizing image urls because there will be no match in the translation catalog after localization. 
- Raise `NotTranslatable` for strings we can't translate in assessment items (this makes them unavailable in exercises) <--- just realized the last commit doesn't add much value. I'll have to revisit later.