### PR TITLE
Build new/missing language packs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ hi: pex
 ka: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite ka 0.17 --out=out/langpacks/ka.zip --no-assessment-resources
 
+kn: pex
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite kn 0.17 --out=out/langpacks/kn.zip --no-assessment-resources
+
+my: pex
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite my 0.17 --out=out/langpacks/my.zip --no-assessment-resources
+
 pl: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite pl 0.17 --out=out/langpacks/pl.zip --no-assessment-resources
 
@@ -55,10 +61,14 @@ ta: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite ta 0.17 --out=out/langpacks/ta.zip --no-assessment-resources
 
 
+zul: pex
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite zul 0.17 --out=out/langpacks/zul.zip --no-assessment-resources
+
+
 all: supported
 
 
-langpacks: pt-PT es pt-BR bn de fr da bg id hi xh ta ka sw
+langpacks: pt-PT es pt-BR bn de fr da bg id hi xh ta ka sw ar kn my pl
 	unzip -p out/en.zip content.db > content.db
 	./makecontentpacks collectmetadata.py out/langpacks/ --out=out/all_metadata.json
 

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ ta: pex
 	PEX_MODULE=contentpacks ./makecontentpacks ka-lite ta 0.17 --out=out/langpacks/ta.zip --no-assessment-resources
 
 
-zul: pex
-	PEX_MODULE=contentpacks ./makecontentpacks ka-lite zul 0.17 --out=out/langpacks/zul.zip --no-assessment-resources
+zu: pex
+	PEX_MODULE=contentpacks ./makecontentpacks ka-lite zu 0.17 --out=out/langpacks/zu.zip --no-assessment-resources
 
 
 all: supported


### PR DESCRIPTION
## Summary
Include some missing language packs in the `Makefile`. 

## Build

- [x]  ar
- [x]  kn
- [x]  my
- [x]  pl
- [ ]  zul

you can grab it here:
https://drive.google.com/open?id=0B-E59G3J_sXmamw4T3hkdEJ0VzQ

## Issues 

zul langpacks is not available.
```
  File "/Users/mrpau-eduard/.pex/install/requests-2.8.1-py3.5.egg.d5c822029bc1b6f22fc7616f965545ca34737c57/requests-2.8.1-py3.5.egg/requests/models.py", line 837, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://api.crowdin.com/api/project/ka-lite/download/zul.zip?key=9f73dca5f1c462ed6e379d54ac33904d
make: *** [zul] Error 1
```

