### PR TITLE
Fix videos only showing in one content node

### DIFF
--- a/contentpacks/generate_dubbed_video_mappings.py
+++ b/contentpacks/generate_dubbed_video_mappings.py
@@ -48,7 +48,7 @@ def download_ka_dubbed_video_csv(download_url=None, is_khan_csv=False, cache_fil
             csv_url = "http://www.khanacademy.org/r/translationmapping"
         logging.info("Getting spreadsheet location from (%s)" % csv_url)
         try:
-            download_url = urllib.request.urlopen(csv_url).geturl()
+            download_url = requests.get(csv_url).url
             if "docs.google.com" not in download_url:
                 logging.warn("Redirect location no longer in Google docs (%s)" % download_url)
             else:

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -309,6 +309,10 @@ slug_blacklist += ["mortgage-interest-rates", "factor-polynomials-using-the-gcf"
 # 'Applying the metric system' at http://s3.amazonaws.com/KA-youtube-converted/CDvPPsB3nEM.mp4/CDvPPsB3nEM.mp4...
 # 'Mixed numbers: changing to improper fractions' at http://s3.amazonaws.com/KA-youtube-converted/xkg7370cpjs.mp4/xkg7370cpjs.mp4...
 
+# French language videos that appears in the english content 
+slug_blacklist += ["be-1ere-primaire", "be-2eme-primaire", "be-3eme-primaire", "be-4eme-primaire",
+                   "be-6eme-primaire", "be-5eme-primaire"]
+
 slug_key = {
     "Topic": "slug",
     "Video": "readable_id",

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -51,7 +51,7 @@ TOPIC_ATTRIBUTES = [
 
 EXERCISE_ATTRIBUTES = [
     'allAssessmentItems',
-    'curatedRelatedVideos',
+    # 'curatedRelatedVideos',
     'description',
     'displayName',
     'fileName',
@@ -416,7 +416,6 @@ def create_paths_remove_orphans_and_empty_topics(nodes) -> list:
         logging.debug("Node count: {}".format(node_count))
 
         children = node.pop("child_data", [])
-
         if children:
             # Use a deepcopy here, in order to create an entirely separate node, not referencing any child objects
             # This avoids any nested data in the node data being shared across nodes.
@@ -424,6 +423,7 @@ def create_paths_remove_orphans_and_empty_topics(nodes) -> list:
             children = [copy.deepcopy(node_dict.get(child.get("id"))) for child in children if node_dict.get(child.get("id"))]
 
             counts = reduce(group_by_slug, children, {})
+
             for items in counts.values():
                 # Slug has more than one item!
                 if len(items) > 1:
@@ -575,7 +575,7 @@ def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no
     node_data = []
     topic_path_list = []
     exercise_ids = []
-    youtube_ids = []
+    video_path_list = []
 
     """
     Get all possible language codes for the language because one language may have multiple language codes or names.  
@@ -614,10 +614,10 @@ def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no
                     exercise_ids.append(node_temp["id"])
                     node_data.append(node_temp)    
             if (node_kind == NodeType.video):
-                if not node_temp["youtube_id"] in youtube_ids:
+                if not node_temp["path"] in video_path_list:
                     youtube_lang = node_temp["translated_youtube_lang"]
                     if youtube_lang == lang:
-                        youtube_ids.append(node_temp["youtube_id"])
+                        video_path_list.append(node_temp["path"])
                         node_data.append(node_temp)
                     elif not youtube_lang == EN_LANG_CODE:
                         """
@@ -626,11 +626,12 @@ def retrieve_kalite_data(lang=EN_LANG_CODE, force=False, ka_domain=KA_DOMAIN, no
                             language code.
                         Example: using pt-BR language code in the khan api will return pt translated_youtube_lang.
                         """
-                        youtube_ids.append(node_temp["youtube_id"])
+                        video_path_list.append(node_temp["path"])
                         node_temp["translated_youtube_lang"] = lang
                         node_data.append(node_temp)
     if not lang == EN_LANG_CODE and not no_dubbed_videos:
         node_data = add_dubbed_video_mappings(node_data, lang)
+        
     return node_data
 
 

--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -528,7 +528,7 @@ def download_and_clean_kalite_data(url, path, lang=EN_LANG_CODE) -> str:
         if not (hidden or dnp or deleted) or node.get("id") == "x00000000":
             topic_nodes.append(node)
 
-    # Hack to add our custom paths
+    # Hack to apply custom paths for our well-known math subtopics
     topic_nodes = apply_well_known_math_subtopics(topic_nodes)
 
     node_data["topics"] = topic_nodes
@@ -1031,7 +1031,7 @@ def get_content_length(content):
 
 
 def apply_dubbed_video_map(content_data: list, subtitles: list, lang: str) -> (list, int):
-    dubbed_count = sum(item.get("kind") == NodeType.video for item in content_data)
+    dubbed_count = len(set([item["id"] for item in content_data if item["kind"] == NodeType.video]))
     if lang != EN_LANG_CODE:
         dubbed_content = []
         for item in content_data:

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -676,7 +676,7 @@ def recurse_availability_up_tree(nodes, db) -> [Item]:
         # and remote_sizes. So, loop over exercises and other content,
         # and skip topics as they will be recursed upwards.
         for node in (n for n in nodes if n.kind != NodeType.topic):
-            logging.info("Saving '{title}'".format(title=node.title))
+            logging.info("Marking availability for {kind}: '{title}'".format(kind=node.kind, title=node.title))
             _recurse_availability_up_tree(node)
 
     return nodes
@@ -831,7 +831,7 @@ def apply_well_known_math_subtopics(topic_nodes: list) -> list:
                 # Remove our well known subtopics from the math children
                 if child.get("id") not in remove_from_topics:
                     new_math_children.append(child)
-            # Add our well-math subtopics
+            # Add our well-known math subtopics
             for topic in known_math_subtopics:
                 new_math_children.append({"id": topic["id"], "kind": topic["kind"]})
             node["child_data"] = new_math_children

--- a/contentpacks/utils.py
+++ b/contentpacks/utils.py
@@ -676,6 +676,7 @@ def recurse_availability_up_tree(nodes, db) -> [Item]:
         # and remote_sizes. So, loop over exercises and other content,
         # and skip topics as they will be recursed upwards.
         for node in (n for n in nodes if n.kind != NodeType.topic):
+            logging.info("Saving '{title}'".format(title=node.title))
             _recurse_availability_up_tree(node)
 
     return nodes
@@ -775,8 +776,8 @@ def apply_well_known_math_subtopics(topic_nodes: list) -> list:
         khan/math/in-in-grade-11-ncert/ to khan/math/india/in-in-grade-11-ncert/
     """
     logging.info("Applying well known math subtopics..")
-    known_math_subtopics = {
-        "india": {
+    known_math_subtopics = [
+        {
             "title_pattern": "Class [0-9]+ \(India\)",
             "title": "Math (India)",
             "id": "x000india", # Just a custom id
@@ -784,7 +785,7 @@ def apply_well_known_math_subtopics(topic_nodes: list) -> list:
             "slug": "india",
             "child_data": [],
         },
-        "eureka": {
+        {
             "title_pattern": "\(Eureka Math/EngageNY\)",
             "title": "Math (Eureka)",
             "id": "x000eureka",
@@ -792,7 +793,7 @@ def apply_well_known_math_subtopics(topic_nodes: list) -> list:
             "slug": "eureka",
             "child_data": [],
         },
-        "canada": {
+        {
             "title_pattern": "[1-9].[sth] grade \(Ontario\)",
             "title": "Math (Canada)",
             "id": "x000canada",
@@ -800,7 +801,7 @@ def apply_well_known_math_subtopics(topic_nodes: list) -> list:
             "kind": "Topic",
             "child_data": [],
         },
-    }
+    ]
 
     remove_from_topics = []
     for node in topic_nodes:
@@ -814,13 +815,13 @@ def apply_well_known_math_subtopics(topic_nodes: list) -> list:
             "sort_order": sort_order, # Temporarily use this to sort the children properly.
             "kind": kind,
         }
-        for k, v in known_math_subtopics.items():
-            if re.search(v["title_pattern"], title):
-                v["child_data"].append(child_data)
+        for topic in known_math_subtopics:
+            if re.search(topic["title_pattern"], title):
+                topic["child_data"].append(child_data)
                 remove_from_topics.append(node_id)
 
-    for k, v in known_math_subtopics.items():
-        v["child_data"].sort(key=lambda k: k["sort_order"])
+    for topic in known_math_subtopics:
+        topic["child_data"].sort(key=lambda k: k["sort_order"])
 
     new_math_children = []
     for node in topic_nodes:
@@ -828,19 +829,19 @@ def apply_well_known_math_subtopics(topic_nodes: list) -> list:
             children = node.get("child_data")
             for child in children:
                 # Remove our well known subtopics from the math children
-                if not child.get("id") in remove_from_topics:
+                if child.get("id") not in remove_from_topics:
                     new_math_children.append(child)
             # Add our well-math subtopics
-            for k, v in known_math_subtopics.items():
-                new_math_children.append({"id": v["id"], "kind": v["kind"]})
+            for topic in known_math_subtopics:
+                new_math_children.append({"id": topic["id"], "kind": topic["kind"]})
             node["child_data"] = new_math_children
             break
 
     # Add our new nodes to the list
-    for k, v in known_math_subtopics.items():
+    for topic in known_math_subtopics:
         # Let's remove the title_pattern before adding it to the nodes.
-        v.pop("title_pattern")
-        topic_nodes.append(v)
+        topic.pop("title_pattern")
+        topic_nodes.append(topic)
     return topic_nodes
 
 


### PR DESCRIPTION
@benjaoming I haven't tested building the content packs yet but what I did was had a `before` and `after` with this one.

I wrote the `before` to a file and the `after` to another file. My only basis was the `Intro to Arcsine` video.

Inside the `before`, `Intro to Arcsine` only appears once. But now, it appears 5 times in different topic nodes.

Before:
![screen shot 2017-12-22 at 11 58 21 am](https://user-images.githubusercontent.com/27984604/34284807-b066d560-e70f-11e7-996a-bff2ebfe8115.png)

After:
![screen shot 2017-12-22 at 11 58 36 am](https://user-images.githubusercontent.com/27984604/34284826-d389d3c6-e70f-11e7-87ad-5426d5f6e03f.png)

I'll try to build the content packs again. Hopefully it fixes most of the issues regarding "missing" videos 🤞 

Also, thanks to @rtibbles for mentioning about this bug 👍 